### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         run: echo ::set-output name=tag::$(echo ${GITHUB_REF:10})
             
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           DOCKER_BUILDKIT: 1
         with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore